### PR TITLE
Enhancements and Fixes to Content Update and Reboot Logic

### DIFF
--- a/pan_ztp_patcher/app.py
+++ b/pan_ztp_patcher/app.py
@@ -133,7 +133,7 @@ def main():
 
     if not changed_password:
         logger.error("Failed to change the firewall password.")
-        # sys.exit(1)
+        sys.exit(1)
 
     # Retrieve the API key
     api_key = retrieve_api_key(

--- a/pan_ztp_patcher/app.py
+++ b/pan_ztp_patcher/app.py
@@ -278,6 +278,7 @@ def main():
                         logger.info(
                             "Specific content installed successfully from servers."
                         )
+                        break
                     else:
                         logger.warning(
                             "Failed to install specific content from servers."
@@ -395,6 +396,10 @@ def main():
         else:
             logger.warning("Failed to reset the firewall data.")
             attempt += 1
+
+    if attempt > max_attempts:
+        logger.error("Failed to reset private data.")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/pan_ztp_patcher/app.py
+++ b/pan_ztp_patcher/app.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 from pan_ztp_patcher.utils import setup_logging
 from pan_ztp_patcher.ztp_patcher import (
     change_firewall_password,
+    check_content_installed,
     check_content_version,
     download_software,
     copy_content_via_scp,
@@ -16,6 +17,7 @@ from pan_ztp_patcher.ztp_patcher import (
     install_content_via_usb,
     monitor_job_status,
     private_data_reset,
+    reboot_firewall,
     retrieve_api_key,
     retrieve_license,
 )
@@ -147,6 +149,29 @@ def main():
         sys.exit(1)
 
     logger.info("API key retrieved successfully.")
+
+    # -----------------------------------------------------------------------
+    # Check to see if the device has content installed already
+    # -----------------------------------------------------------------------
+    content_installed = check_content_installed(
+        api_key=api_key,
+        pan_hostname=pan_hostname,
+    )
+
+    # If content is already installed, reboot the firewall
+    if content_installed:
+        logger.info("Content already installed, rebooting the firewall.")
+        reboot = reboot_firewall(
+            api_key=api_key,
+            pan_hostname=pan_hostname,
+        )
+
+        if reboot:
+            logger.info("Firewall rebooted successfully.")
+            sys.exit(0)
+        else:
+            logger.error("Failed to reboot the firewall.")
+            sys.exit(1)
 
     # ------------------------------------------------------------------------
     # Retrieve License Workflow

--- a/pan_ztp_patcher/ztp_patcher.py
+++ b/pan_ztp_patcher/ztp_patcher.py
@@ -100,6 +100,93 @@ def change_firewall_password(
         return False
 
 
+def check_content_installed(
+    api_key: str,
+    pan_hostname: str,
+) -> bool:
+    """
+    Checks if content is installed on the PAN-OS firewall.
+
+    Args:
+        api_key (str): The API key for authentication.
+        pan_hostname (str): The hostname or IP address of the PAN-OS firewall.
+
+    Returns:
+        bool: True if content is installed, False otherwise.
+    """
+
+    logger.info("=" * 79)
+    logger.info("Checking if content is installed...")
+    logger.info("=" * 79)
+
+    try:
+        # Construct the API URL for checking installed content
+        url = "https://{}/api/?type=op&cmd={}".format(
+            pan_hostname,
+            urllib.parse.quote_plus(
+                "<request><content><upgrade><check/></upgrade></content></request>"
+            ),
+        )
+        logger.debug("API URL: {}".format(url))
+
+        # Create an HTTPS request with SSL verification disabled
+        request = urllib.request.Request(url)
+        request.add_header("X-PAN-KEY", api_key)
+
+        # Send the API request
+        logger.debug("Sending API request...")
+        response = urllib.request.urlopen(
+            request, context=urllib.request.ssl._create_unverified_context()
+        )
+
+        # Read the response content
+        logger.debug("Reading response content...")
+        response_content = response.read().decode("utf-8")
+        logger.debug("Received response: {}".format(response_content))
+
+        # Parse the XML response
+        logger.debug("Parsing XML response...")
+        root = ET.fromstring(response_content)
+        logger.debug("Root element: {}".format(root.tag))
+
+        # Check the response status
+        if root.attrib.get("status") == "success":
+            content_updates = root.find("./result/content-updates")
+
+            # Check if there are any <entry> elements within <content-updates>
+            if (
+                content_updates is not None
+                and len(content_updates.findall("./entry")) > 0
+            ):
+                logger.info("Content is installed.")
+                return True
+            else:
+                logger.info("No content installed.")
+                return False
+
+        else:
+            error_message = root.find("./msg/line")
+            if error_message is not None:
+                logger.error(
+                    "API request failed: {}".format(error_message.text)
+                )
+            else:
+                logger.error("API request failed.")
+            return False
+
+    except urllib.error.URLError as url_error:
+        logger.error("URL error occurred: {}".format(str(url_error)))
+        return False
+
+    except ET.ParseError as parse_error:
+        logger.error("XML parsing error occurred: {}".format(str(parse_error)))
+        return False
+
+    except Exception as e:
+        logger.error("An error occurred: {}".format(str(e)))
+        return False
+
+
 def check_content_version(
     api_key: str,
     content_version: str,
@@ -885,6 +972,73 @@ def private_data_reset(
 
             # Send the API request
             logger.debug("Sending job monitoring request...")
+            response = urllib.request.urlopen(
+                request,
+                context=urllib.request.ssl._create_unverified_context(),
+            )
+
+            # Check the status code
+            if response.getcode() != 200:
+                raise ValueError(
+                    "HTTP request failed with status code: {}".format(
+                        response.getcode()
+                    )
+                )
+
+            # Read the response content
+            logger.debug("Reading response content...")
+            response_content = response.read().decode("utf-8")
+            logger.debug("Received response: {}".format(response_content))
+
+            return True
+
+        except urllib.error.URLError as url_error:
+            logger.error("URL error occurred: {}".format(str(url_error)))
+            return False
+
+        except ET.ParseError as parse_error:
+            logger.error(
+                "XML parsing error occurred: {}".format(str(parse_error))
+            )
+            return False
+
+        except Exception as e:
+            logger.error("An error occurred: {}".format(str(e)))
+            return False
+
+
+def reboot_firewall(
+    api_key: str,
+    pan_hostname: str,
+):
+    """_summary_
+
+    Args:
+        api_key (str): _description_
+        pan_hostname (str): _description_
+    """
+
+    logger.info("=" * 79)
+    logger.info("Rebooting the firewall...")
+    logger.info("=" * 79)
+
+    while True:
+        try:
+            # Construct the API URL for rebooting the firewall
+            url = "https://{}/api/?type=op&cmd={}".format(
+                pan_hostname,
+                urllib.parse.quote_plus(
+                    "<request><restart><system/></restart></request>"
+                ),
+            )
+            logger.debug("Reboot URL: {}".format(url))
+
+            # Create an HTTPS request with SSL verification disabled
+            request = urllib.request.Request(url)
+            request.add_header("X-PAN-KEY", api_key)
+
+            # Send the API request
+            logger.debug("Sending reboot request...")
             response = urllib.request.urlopen(
                 request,
                 context=urllib.request.ssl._create_unverified_context(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-ztp-patcher"
-version = "0.2.8"
+version = "0.2.9"
 description = "Update content version on PAN-OS firewalls"
 authors = ["Calvin Remsburg <cremsburg.dev@gmail.com>"]
 license = "Apache2.0"

--- a/tests/test_check_content_installed.py
+++ b/tests/test_check_content_installed.py
@@ -1,0 +1,53 @@
+# tests/test_check_content_installed.py
+
+from unittest.mock import MagicMock, patch
+from pan_ztp_patcher.ztp_patcher import check_content_installed
+
+
+def test_check_content_installed_success():
+    api_key = "your_api_key"
+    pan_hostname = "your_pan_hostname"
+
+    # Mock the API response
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'<response status="success"><result><job>1234</job></result></response>'
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        job_id = check_content_installed(
+            api_key,
+            pan_hostname,
+        )
+
+    assert job_id == "1234"
+
+
+def test_check_content_installed_failure():
+    api_key = "your_api_key"
+    pan_hostname = "your_pan_hostname"
+
+    # Mock the API response
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'<response status="error"><msg><line>API request failed</line></msg></response>'
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        job_id = check_content_installed(
+            api_key,
+            pan_hostname,
+        )
+
+    assert job_id is None
+
+
+def test_check_content_installed_exception():
+    api_key = "your_api_key"
+    pan_hostname = "your_pan_hostname"
+
+    with patch(
+        "urllib.request.urlopen", side_effect=Exception("API request failed")
+    ):
+        job_id = check_content_installed(
+            api_key,
+            pan_hostname,
+        )
+
+    assert job_id is None

--- a/tests/test_check_content_installed.py
+++ b/tests/test_check_content_installed.py
@@ -10,15 +10,18 @@ def test_check_content_installed_success():
 
     # Mock the API response
     mock_response = MagicMock()
-    mock_response.read.return_value = b'<response status="success"><result><job>1234</job></result></response>'
+    mock_response.read.return_value = b'<response status="success"><result><content-updates last-updated-at="2024/04/20 04:10:01 PDT"><entry><version>8831-8669</version><app-version>8831-8669</app-version><filename>panupv2-all-contents-8831-8669</filename><size>86</size><size-kb>89019</size-kb><released-on>2024/04/08 13:28:31 PDT</released-on><release-notes><![CDATA[https://proditpdownloads.paloaltonetworks.com/content/content-8831-8669.html?__token__=exp=1714216359~acl=/content/content-8831-8669.html*~hmac=e9aaf43c583e2902e708bc3be0d6511f189b5f25580110280054eb5b03e3bbda]]></release-notes><downloaded>no</downloaded><current>no</current><previous>no</previous><installing>no</installing><features>Apps, Threats</features><update-type>Full</update-type><feature-desc>Unknown</feature-desc><sha256>ae12ea7da3a05927943c7de3f3441e31d3f1020902a9c9e63885ddf060d84e4d</sha256></entry></content-updates></result></response>'
 
-    with patch("urllib.request.urlopen", return_value=mock_response):
-        job_id = check_content_installed(
+    with patch(
+        "urllib.request.urlopen",
+        return_value=mock_response,
+    ):
+        content_installed = check_content_installed(
             api_key,
             pan_hostname,
         )
 
-    assert job_id == "1234"
+    assert content_installed is True
 
 
 def test_check_content_installed_failure():
@@ -30,12 +33,12 @@ def test_check_content_installed_failure():
     mock_response.read.return_value = b'<response status="error"><msg><line>API request failed</line></msg></response>'
 
     with patch("urllib.request.urlopen", return_value=mock_response):
-        job_id = check_content_installed(
+        content_installed = check_content_installed(
             api_key,
             pan_hostname,
         )
 
-    assert job_id is None
+    assert content_installed is False
 
 
 def test_check_content_installed_exception():
@@ -45,9 +48,9 @@ def test_check_content_installed_exception():
     with patch(
         "urllib.request.urlopen", side_effect=Exception("API request failed")
     ):
-        job_id = check_content_installed(
+        content_installed = check_content_installed(
             api_key,
             pan_hostname,
         )
 
-    assert job_id is None
+    assert content_installed is False

--- a/tests/test_reboot_firewall.py
+++ b/tests/test_reboot_firewall.py
@@ -1,0 +1,45 @@
+# tests/test_check_content_version_found.py
+
+from unittest.mock import MagicMock, patch
+from pan_ztp_patcher.ztp_patcher import reboot_firewall
+
+
+def test_reboot_firewall_success():
+    api_key = "your_api_key"
+    pan_hostname = "your_pan_hostname"
+
+    # Mock the API response
+    mock_response = MagicMock()
+    mock_response.getcode.return_value = 200
+    mock_response.read.return_value = b'<response status="success"/>'
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        result = reboot_firewall(api_key, pan_hostname)
+
+    assert result is True
+
+
+def test_reboot_firewall_failure():
+    api_key = "your_api_key"
+    pan_hostname = "your_pan_hostname"
+
+    # Mock the API response
+    mock_response = MagicMock()
+    mock_response.getcode.return_value = 500
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        result = reboot_firewall(api_key, pan_hostname)
+
+    assert result is False
+
+
+def test_reboot_firewall_exception():
+    api_key = "your_api_key"
+    pan_hostname = "your_pan_hostname"
+
+    with patch(
+        "urllib.request.urlopen", side_effect=Exception("Reboot request failed")
+    ):
+        result = reboot_firewall(api_key, pan_hostname)
+
+    assert result is False


### PR DESCRIPTION
## Description:

This pull request introduces a set of enhancements and bug fixes aimed at improving the robustness and functionality of the PAN-OS ZTP Patcher. Key improvements include refined error handling, additional testing, and a refactor of key components to enhance reliability and maintainability. Below is a summary of the changes:

## Enhancements:

- Refactored API Key Retrieval: Implemented retry logic in the retrieve_api_key function to enhance robustness when fetching the API key, improving reliability in unstable network conditions.
- Reboot Logic Added: Integrated logic to check if content is already installed and, if so, reboot the firewall, streamlining the update process.
- Updated Versioning: Bumped the software version to 0.2.9 to mark the new enhancements and fixes.

## Bug Fixes:

- Graceful Exit on Password Change Failure: Modified the script to exit gracefully if the firewall password change fails, ensuring that subsequent steps do not proceed on a failed authentication.
- Fix in Private Data Reset Workflow: Addressed an issue where the private data reset in the main function was not executing correctly, ensuring that the function performs as intended.

## Testing:

New Tests for Content Check and Reboot Functions: Added unit tests for the check_content_installed and reboot_firewall functions to validate functionality and enhance reliability through automated testing frameworks.

## Files Modified:

- app.py: Added reboot logic and improved error handling.
- ztp_patcher.py: Refactored retrieve_api_key, added check_content_installed, and implemented reboot logic.
- pyproject.toml: Version bump to 0.2.9.
- Tests: Added new test scripts for checking installed content and reboot functionality.

## Impact:

These changes are expected to improve the efficiency of deployments by reducing manual error, improving automated processes, and ensuring that firewalls are always operating with the latest security measures in place.

